### PR TITLE
Add pixel_sixe and fiducial_locations to params

### DIFF
--- a/array_analyzer/extract/image_parser.py
+++ b/array_analyzer/extract/image_parser.py
@@ -306,7 +306,7 @@ def generate_props_dict(props_, n_rows, n_cols, min_area=100, img_x_max=2048, im
     return cent_map
 
 
-def find_fiducials_markers(props_, fiducial_locations, n_rows, n_cols, v_pitch, h_pitch, img_size, pix_size):
+def find_fiducials_markers(props_, params_, img_size):
     """
     based on the region props, creates a dictionary of format:
         key = (centroid_x, centroid_y)
@@ -314,21 +314,19 @@ def find_fiducials_markers(props_, fiducial_locations, n_rows, n_cols, v_pitch, 
 
     :param props_: list of region props
         approximately 36-48 of these, depending on quality of the image
-    :param fiducial_locations: list specifying location of fiducial markers, e.g.
-        [(0,0), (0,5), (5,0)] for markers at 3 corners of 6x6 array
-    :param n_rows: int
-    :param n_cols: int
-    :param v_pitch: float
-        vertical spot center distance in mm
-    :param h_pitch: float
-        horizontal spot center distance in mm
+    :param params: dict
     :param img_size tuple
         image size in pixels
-    :param pix_size: float
-        size of pix in mm
     :return: dict
         of format (cent_x, cent_y): prop for fiducials only
     """
+
+    fiducial_locations = params_['fiducial_locations']
+    n_rows = params_['rows']
+    n_cols = params_['columns']
+    v_pitch = params_['v_pitch']
+    h_pitch = params_['h_pitch']
+    pix_size = params_['pixel_size']
 
     centroids_in_mm = np.array([p.centroid for p in props_]) * pix_size
     spots_x, spots_y = (centroids_in_mm[:,1], centroids_in_mm[:,0])
@@ -477,7 +475,7 @@ def assign_props_to_array_2(arr, cent_map_):
     return arr
 
 
-def build_block_array(params_, pix_size=0.0049):
+def build_block_array(params_):
     """
     builds a binary array of squares centered on the expected spot position
     The array dimensions are based on parsed .xml values from the print run
@@ -487,15 +485,13 @@ def build_block_array(params_, pix_size=0.0049):
 
     :param params_: dict
         param dictionary from "create_xml_dict"
-    :param pix_size: float
-        size of pix in mm
     :return: np.ndarray, origin
 
     """
 
     # fix the pixel size, for now, in mm
-    PIX_SIZE = pix_size
-    PIX_SIZE = 0.00185
+    PIX_SIZE = params_['pixel_size']
+    # PIX_SIZE = 0.00185
 
     n_rows = params_['rows']
     n_cols = params_['columns']

--- a/run_array_analyzer.py
+++ b/run_array_analyzer.py
@@ -131,6 +131,16 @@ def workflow(input_folder_, output_folder_, debug=False):
     # parsing .xml
     fiduc, spots, repl, params = create_xml_dict(xml_path)
 
+    # add fiducial locations and pixel size to params
+    # TODO: ged fiducial locations from xkappa-biotin locations in xml file
+
+    # for scienion images
+    # params['fiducial_locations'] = [(0, 0), (0, 1), (0, 5), (7, 0), (7, 5)]
+    # params['pixel_size'] = 0.0049 # in mm
+    # for octopi images
+    params['fiducial_locations'] = [(0, 0), (0, 5), (5, 0), (5, 5)]
+    params['pixel_size'] = 0.00185 # in mm
+
     # creating our arrays
     spot_ids = create_array(params['rows'], params['columns'])
     antigen_array = create_array(params['rows'], params['columns'])
@@ -165,7 +175,7 @@ def workflow(input_folder_, output_folder_, debug=False):
     #TODO: select wells based to analyze based on user input (Bryant)
 
     # wellimages = ['H10.png','H11.png','H12.png']
-    # wellimages = ['H8.png']
+    # wellimages = ['H10.png']
     for well in wellimages:
         start = time.time()
         image, image_name = read_to_grey(input_folder_, well)
@@ -186,16 +196,9 @@ def workflow(input_folder_, output_folder_, debug=False):
         props = select_props(props, attribute="area", condition="greater_than", condition_value=200)
         # props = select_props(props, attribute="eccentricity", condition="less_than", condition_value=0.75)
 
-        fiducial_locations = [(0, 0), (0, 1), (0, 5), (7, 0), (7, 5)]
-        pix_size = 0.0049 # in mm
         props_by_loc = find_fiducials_markers(props,
-                                              fiducial_locations,
-                                              params['rows'],
-                                              params['columns'],
-                                              params['v_pitch'],
-                                              params['h_pitch'],
-                                              im_crop.shape,
-                                              pix_size)
+                                              params,
+                                              im_crop.shape)
 
 
         # for grid fit, this props dict is used only for finding fiducials
@@ -284,6 +287,7 @@ if __name__ == "__main__":
                   'Plates_given_to_manu/2020-01-15_plate4_AEP_Feb3_6mousesera'
 
     flags = ['-i', input_path, '-o', output_path, '-d']
+    # flags = ['-i', input_path, '-o', output_path]
     main(flags)
 
     # main(sys.argv[1:])


### PR DESCRIPTION
Added pixel_sixe and fiducial_locations to params.

Previously, there was a problems with hardcoded parameters being different between the scienion and octopi data sets. Now they are still hardcoded, but I've moved them further up (line 137 - 142 of run_array_analyzer). Remember to switch between the two when switching between data sets.

TODO: Get fiducial locations from locations of xkappa-biotion from metadata. Find a way to get pixel_size from metadata also.