### PR TITLE
fixed and verified OD calculation

### DIFF
--- a/array_analyzer/workflows/registration_workflow.py
+++ b/array_analyzer/workflows/registration_workflow.py
@@ -144,13 +144,13 @@ def point_registration(input_folder, output_folder, debug=False):
         )
 
         # Estimate and remove background
+        im_crop = im_crop.astype('float64')
+        im_crop /= 255.0
         background = img_processing.get_background(
             im_crop,
             fit_order=2,
-            normalize=True,
+            normalize=False,
         )
-        im_crop = im_crop / background
-        im_crop = u.invert(im_crop)
 
         placed_spotmask = array_gen.build_centroid_binary_blocks(
             crop_coords,
@@ -232,7 +232,7 @@ def point_registration(input_folder, output_folder, debug=False):
             # Evaluate accuracy of background estimation with green (image), magenta (background) overlay.
             im_bg_overlay = np.stack([background, im_crop, background], axis=2)
             io.imsave(output_name + "_crop_bg_overlay.png",
-                      im_bg_overlay.astype('uint8'))
+                      (255 * im_bg_overlay).astype('uint8'))
 
             # This plot shows which spots have been assigned what index.
             debug_plots.plot_spot_assignment(

--- a/array_analyzer/workflows/registration_workflow.py
+++ b/array_analyzer/workflows/registration_workflow.py
@@ -223,14 +223,14 @@ def point_registration(input_folder, output_folder, debug=False):
 
             # Save mask of the well, cropped grayscale image, cropped spot segmentation.
             io.imsave(output_name + "_well_mask.png",
-                      (np.iinfo(placed_spotmask.dtype).max * placed_spotmask).astype('uint8'))
+                      (255 * placed_spotmask).astype('uint8'))
             io.imsave(output_name + "_crop.png",
-                      (np.iinfo(im_crop.dtype).max * im_crop).astype('uint8'))
+                      (255 * im_crop).astype('uint8'))
 
             # Evaluate accuracy of background estimation with green (image), magenta (background) overlay.
             im_bg_overlay = np.stack([background, im_crop, background], axis=2)
             io.imsave(output_name + "_crop_bg_overlay.png",
-                      (np.iinfo(im_bg_overlay.dtype).max * im_bg_overlay).astype('uint8'))
+                      (255 * im_bg_overlay).astype('uint8'))
 
             # This plot shows which spots have been assigned what index.
             debug_plots.plot_spot_assignment(

--- a/array_analyzer/workflows/registration_workflow.py
+++ b/array_analyzer/workflows/registration_workflow.py
@@ -144,12 +144,10 @@ def point_registration(input_folder, output_folder, debug=False):
         )
 
         # Estimate and remove background
-        im_crop = im_crop.astype('float64')
-        im_crop /= 255.0
+        im_crop = im_crop/np.iinfo(im_crop.dtype).max
         background = img_processing.get_background(
             im_crop,
             fit_order=2,
-            normalize=False,
         )
 
         placed_spotmask = array_gen.build_centroid_binary_blocks(

--- a/array_analyzer/workflows/registration_workflow.py
+++ b/array_analyzer/workflows/registration_workflow.py
@@ -223,14 +223,14 @@ def point_registration(input_folder, output_folder, debug=False):
 
             # Save mask of the well, cropped grayscale image, cropped spot segmentation.
             io.imsave(output_name + "_well_mask.png",
-                      (255 * placed_spotmask).astype('uint8'))
+                      (np.iinfo(placed_spotmask.dtype).max * placed_spotmask).astype('uint8'))
             io.imsave(output_name + "_crop.png",
-                      (255 * im_crop).astype('uint8'))
+                      (np.iinfo(im_crop.dtype).max * im_crop).astype('uint8'))
 
             # Evaluate accuracy of background estimation with green (image), magenta (background) overlay.
             im_bg_overlay = np.stack([background, im_crop, background], axis=2)
             io.imsave(output_name + "_crop_bg_overlay.png",
-                      (255 * im_bg_overlay).astype('uint8'))
+                      (np.iinfo(im_bg_overlay.dtype).max * im_bg_overlay).astype('uint8'))
 
             # This plot shows which spots have been assigned what index.
             debug_plots.plot_spot_assignment(
@@ -254,7 +254,7 @@ def point_registration(input_folder, output_folder, debug=False):
             print(f"Time to save debug images: {time.time()-start_time} s")
 
             # # Save image with spots
-            im_roi = (255*im_crop.copy()).astype('uint8')
+            im_roi = (np.iinfo(im_crop.dtype).max*im_crop.copy()).astype('uint8')
             im_roi = cv.cvtColor(im_roi, cv.COLOR_GRAY2RGB)
             plt.imshow(im_roi)
             # shift the spot and grid coords based on "crop"


### PR DESCRIPTION
To be consistent with how OD is calculated using the "interpolation" method, we have to rescale the cropped image to be range 0-1, float64, not inverted.

After doing this, I can verify by eye that the plots from the two approaches (interpolation and fit) are similar.  This verification was done only on April flu plates.  Please see [data here](https://drive.google.com/drive/folders/1--r_pLNfQB8pT8duRBYuLAocqUAmwNDC?usp=sharing) for the debug outputs of that run:

