### PR TITLE
Fine tune fishy registration 

### DIFF
--- a/array_analyzer/extract/img_processing.py
+++ b/array_analyzer/extract/img_processing.py
@@ -211,6 +211,7 @@ def get_spot_coords(im,
     im_norm[im_norm < 0] = 0
     im_norm[im_norm > max_intensity] = max_intensity
     im_norm = im_norm.astype(np.uint8)
+
     # Detect peaks in filtered image
     keypoints = detector.detect(im_norm)
 
@@ -232,7 +233,7 @@ def get_spot_coords(im,
             idx += 1
     spot_coords = spot_coords[:idx, :]
 
-    return spot_coords
+    return spot_coords, im_norm
 
 
 def find_profile_peaks(profile, margin, prominence):


### PR DESCRIPTION
The LoG filter @jennyfolkesson added in #60 works great. This PR adds a check to reduce sigma of LoG filter when registration failed to enhance the contrast of dim fiducials, and run registration again. This fixes the failed registration in dataset 2020-05-02-13-49-02-COVID_May2_JVassay_FcIgGplate_images ('A6', 'A11', 'D12', 'E1', 'E6', 'F1', 'F6'). Haven't tested this fix on cuttlefish data but happy to test if @jennyfolkesson you can share the pycharm run config. 

Also save LoG filtered image when run in debug mode. Found it useful for tuning size of LoG filter.