### PR TITLE
when building a target image, must slice into it in [col, row] order

### DIFF
--- a/array_analyzer/load/debug_plots.py
+++ b/array_analyzer/load/debug_plots.py
@@ -37,11 +37,12 @@ def assign_region(target_, props_, intensity_image_=None):
     :return:
     """
 
-    min_row, min_col, max_row, max_col = props_.bbox
+    # min_row, min_col, max_row, max_col = props_.bbox
+    min_col, min_row, max_col, max_row = props_.bbox
     if intensity_image_ is None:
-        target_[min_col:max_col, min_row:max_row] = props_.intensity_image
+        target_[min_row:max_row, min_col:max_col] = props_.intensity_image
     else:
-        target_[min_col:max_col, min_row:max_row] = intensity_image_[min_col:max_col, min_row:max_row]
+        target_[min_row:max_row, min_col:max_col] = intensity_image_[min_row:max_row, min_col:max_col]
     return target_
 
 

--- a/array_analyzer/load/debug_plots.py
+++ b/array_analyzer/load/debug_plots.py
@@ -39,10 +39,9 @@ def assign_region(target_, props_, intensity_image_=None):
 
     min_row, min_col, max_row, max_col = props_.bbox
     if intensity_image_ is None:
-        target_[min_row:max_row, min_col:max_col] = props_.intensity_image
+        target_[min_col:max_col, min_row:max_row] = props_.intensity_image
     else:
-        target_[min_row:max_row, min_col:max_col] = intensity_image_[min_row:max_row, min_col:max_col]
-
+        target_[min_col:max_col, min_row:max_row] = intensity_image_[min_col:max_col, min_row:max_row]
     return target_
 
 


### PR DESCRIPTION
very small fix in the way the composite_spots_img is generated.

The target image needs to be sliced in [col, row] order.  This only influences the way debug data is generated.