### PR TITLE
Nonetype well registration

### DIFF
--- a/array_analyzer/extract/img_processing.py
+++ b/array_analyzer/extract/img_processing.py
@@ -194,19 +194,19 @@ def crop_image_from_coords(im, grid_coords, margin=200):
         in the cropped image (nbr points x 2)
     :param int margin: How much margin around the coordinates
     :return np.array im_roi: Cropped image
-    :return np.array grid_coords: Grid coordinates with new origin
+    :return np.array grid_coords: Grid coordinates with new origin (rows, cols)
     """
     im_shape = im.shape
-    x_min = int(max(0, np.min(grid_coords[:, 0]) - margin))
-    x_max = int(min(im_shape[1], np.max(grid_coords[:, 0]) + margin))
-    y_min = int(max(0, np.min(grid_coords[:, 1]) - margin))
-    y_max = int(min(im_shape[0], np.max(grid_coords[:, 1]) + margin))
-    im_crop = im[y_min:y_max, x_min:x_max]
+    row_min = int(max(0, np.min(grid_coords[:, 0]) - margin))
+    row_max = int(min(im_shape[0], np.max(grid_coords[:, 0]) + margin))
+    col_min = int(max(0, np.min(grid_coords[:, 1]) - margin))
+    col_max = int(min(im_shape[1], np.max(grid_coords[:, 1]) + margin))
+    im_crop = im[row_min:row_max, col_min:col_max]
 
     # Update coordinates with new origin
     crop_coords = grid_coords.copy()
-    crop_coords[:, 0] = crop_coords[:, 0] - x_min + 1
-    crop_coords[:, 1] = crop_coords[:, 1] - y_min + 1
+    crop_coords[:, 0] = crop_coords[:, 0] - row_min + 1
+    crop_coords[:, 1] = crop_coords[:, 1] - col_min + 1
     return im_crop, crop_coords
 
 
@@ -304,24 +304,19 @@ class SpotDetector:
                  imaging_params,
                  min_thresh=100,
                  max_thresh=255,
-                 max_area=10000,
                  min_circularity=.1,
                  min_convexity=.5,
                  min_dist_between_blobs=10,
-                 min_repeatability=2,
-                 max_intensity=255):
+                 min_repeatability=2):
         """
         :param int min_thresh: Minimum threshold
         :param int max_thresh: Maximum threshold
-        :param int min_area: Minimum spot area in pixels
-        :param int max_area: Maximum spot area in pixels
         :param float min_circularity: Minimum circularity of spots
         :param float min_convexity: Minimum convexity of spots
         :param float min_dist_between_blobs: minimal distance in pixels between two
             spots for them to be called as different spots
         :param int min_repeatability: minimal number of times the same spot has to be
             detected at different thresholds
-        :param int max_intensity: Maximum image intensity (default uint8)
         """
 
         self.min_thresh = min_thresh
@@ -330,11 +325,10 @@ class SpotDetector:
         self.min_repeatability = min_repeatability
         self.min_circularity = min_circularity
         self.min_convexity = min_convexity
-        self.max_intensity = max_intensity
         self.sigma_gauss = int(np.round(imaging_params['spot_width'] /
                                 imaging_params['pixel_size'] / 4))
         self.min_area = 4 * self.sigma_gauss ** 2
-        self.max_area = max_area
+        self.max_area = 50 * self.min_area
         self.nbr_expected_spots = imaging_params['rows'] * imaging_params['columns']
 
         self.blob_detector = self._make_blob_detector()
@@ -359,7 +353,7 @@ class SpotDetector:
         blob_params.minDistBetweenBlobs = self.min_dist_between_blobs
         blob_params.minRepeatability = self.min_repeatability
         # This detects bright spots, which they are after top hat
-        blob_params.blobColor = self.max_intensity
+        blob_params.blobColor = 255
         detector = cv.SimpleBlobDetector_create(blob_params)
         return detector
 
@@ -371,18 +365,23 @@ class SpotDetector:
         :return np.array log_filter: 2D LoG filter
         """
         n = np.ceil(self.sigma_gauss * 6)
-        y, x = np.ogrid[-n // 2:n // 2 + 1, -n // 2:n // 2 + 1]
+        rows, cols = np.ogrid[-n // 2:n // 2 + 1, -n // 2:n // 2 + 1]
         sigma_sq = 2 * self.sigma_gauss ** 2
-        y_filter = np.exp(-(y ** 2 / sigma_sq))
-        x_filter = np.exp(-(x ** 2 / sigma_sq))
-        log_filter = (-sigma_sq + x ** 2 + y ** 2) * \
-                     (x_filter * y_filter) * \
+        row_filter = np.exp(-(rows ** 2 / sigma_sq))
+        col_filter = np.exp(-(cols ** 2 / sigma_sq))
+        log_filter = (-sigma_sq + cols ** 2 + rows ** 2) * \
+                     (col_filter * row_filter) * \
                      (1 / (np.pi * sigma_sq * self.sigma_gauss ** 2))
         # Total filter should sum to 1 to not alter mean intensity
         log_filter = log_filter / sum(sum(log_filter))
         return log_filter
 
-    def get_spot_coords(self, im, margin=0, im_mean=100, im_std=25):
+    def get_spot_coords(self,
+                        im,
+                        margin=0,
+                        im_mean=100,
+                        im_std=25,
+                        max_intensity=255):
         """
         Use OpenCVs simple blob detector (thresholdings and grouping by properties)
         to detect all dark spots in the image. First filter with a Laplacian of
@@ -393,18 +392,19 @@ class SpotDetector:
             ignored (to ignore boundary effects)
         :param float im_mean: Set normalized image to fixed mean
         :param float im_std: Set normalized image to fixed std
-        :return np.array spot_coords: x, y coordinates of spot centroids
+        :param int max_intensity: Maximum image intensity (default uint8)
+        :return np.array spot_coords: row, col coordinates of spot centroids
             (nbr spots x 2)
         """
         # First invert image to detect peaks
-        im_norm = (im.max() - im) / self.max_intensity
+        im_norm = (max_intensity - im) / max_intensity
         # Filter with Laplacian of Gaussian
         im_norm = cv.filter2D(im_norm, -1, self.log_filter)
         # Normalize
         im_norm = im_norm / im_norm.std() * im_std
         im_norm = im_norm - im_norm.mean() + im_mean
         im_norm[im_norm < 0] = 0
-        im_norm[im_norm > self.max_intensity] = self.max_intensity
+        im_norm[im_norm > 255] = 255
         im_norm = im_norm.astype(np.uint8)
 
         # Detect peaks in filtered image
@@ -412,13 +412,13 @@ class SpotDetector:
 
         spot_coords = np.zeros((len(keypoints), 2))
         # Remove outliers and convert to np.array
-        x_max, y_max = im.shape
+        row_max, col_max = im.shape
         idx = 0
         for keypoint in range(len(keypoints)):
             pt = keypoints[keypoint].pt
-            if margin < pt[0] < x_max - margin and margin < pt[1] < y_max - margin:
-                spot_coords[idx, 0] = pt[0]
-                spot_coords[idx, 1] = pt[1]
+            if margin < pt[0] < row_max - margin and margin < pt[1] < col_max - margin:
+                spot_coords[idx, 0] = pt[1]
+                spot_coords[idx, 1] = pt[0]
                 idx += 1
         spot_coords = spot_coords[:idx, :]
         return spot_coords

--- a/array_analyzer/load/debug_plots.py
+++ b/array_analyzer/load/debug_plots.py
@@ -37,7 +37,7 @@ def assign_region(target_, props_, intensity_image_=None):
     :return:
     """
 
-    min_row, min_col, max_row, max_col = props_.bbox
+    min_col, min_row, max_col, max_row = props_.bbox
     if intensity_image_ is None:
         target_[min_row:max_row, min_col:max_col] = props_.intensity_image
     else:

--- a/array_analyzer/load/debug_plots.py
+++ b/array_analyzer/load/debug_plots.py
@@ -37,7 +37,7 @@ def assign_region(target_, props_, intensity_image_=None):
     :return:
     """
 
-    min_col, min_row, max_col, max_row = props_.bbox
+    min_row, min_col, max_row, max_col = props_.bbox
     if intensity_image_ is None:
         target_[min_row:max_row, min_col:max_col] = props_.intensity_image
     else:

--- a/array_analyzer/load/debug_plots.py
+++ b/array_analyzer/load/debug_plots.py
@@ -177,31 +177,34 @@ def plot_registration(image,
                       grid_coords,
                       reg_coords,
                       output_name,
+                      max_intensity=255,
                       margin=100):
     """
     Plots all detected spots, initial fiducial coordinates and registered grid.
 
     :param np.array image: Input image
-    :param np.array spot_coords: Detected spot coordinates (nbr spots x 2)
+    :param np.array spot_coords: Detected spot coordinates (nbr spots x rows, cols)
     :param np.array grid_coords: Initial estimate of fiducial coordinates
     :param np.array reg_coords: Registered coordinates
     :param str output_name: Path + well name, _registration.png will be added
+    :param int max_intensity: Maximum image intensity (expecting uint8 or 16)
     :param int margin: Margin around spots to crop image before plotting
     """
+    im = (image / max_intensity * 255).astype(np.uint8)
 
     all_coords = np.vstack([spot_coords, grid_coords, reg_coords])
     im_shape = image.shape
-    x_min = int(max(0, np.min(all_coords[:, 0]) - margin))
-    x_max = int(min(im_shape[1], np.max(all_coords[:, 0]) + margin))
-    y_min = int(max(0, np.min(all_coords[:, 1]) - margin))
-    y_max = int(min(im_shape[0], np.max(all_coords[:, 1]) + margin))
-    im_roi = image[y_min:y_max, x_min:x_max]
+    row_min = int(max(0, np.min(all_coords[:, 0]) - margin))
+    row_max = int(min(im_shape[0], np.max(all_coords[:, 0]) + margin))
+    col_min = int(max(0, np.min(all_coords[:, 1]) - margin))
+    col_max = int(min(im_shape[1], np.max(all_coords[:, 1]) + margin))
+    im_roi = im[row_min:row_max, col_min:col_max]
 
     im_roi = cv.cvtColor(im_roi, cv.COLOR_GRAY2RGB)
     plt.imshow(im_roi)
-    plt.plot(spot_coords[:, 0] - x_min + 1, spot_coords[:, 1] - y_min + 1, 'rx', ms=8)
-    plt.plot(grid_coords[:, 0] - x_min + 1, grid_coords[:, 1] - y_min + 1, 'b+', ms=8)
-    plt.plot(reg_coords[:, 0] - x_min + 1, reg_coords[:, 1] - y_min + 1, 'g.', ms=8)
+    plt.plot(spot_coords[:, 1] - col_min + 1, spot_coords[:, 0] - row_min + 1, 'rx', ms=8)
+    plt.plot(grid_coords[:, 1] - col_min + 1, grid_coords[:, 0] - row_min + 1, 'b+', ms=8)
+    plt.plot(reg_coords[:, 1] - col_min + 1, reg_coords[:, 0] - row_min + 1, 'g.', ms=8)
     plt.axis('off')
     fig_save = plt.gcf()
     fig_save.savefig(output_name + '_registration.png', bbox_inches='tight')

--- a/array_analyzer/load/report.py
+++ b/array_analyzer/load/report.py
@@ -2,6 +2,7 @@ import array_analyzer.extract.constants as constants
 from copy import deepcopy
 import numpy as np
 import pandas as pd
+import warnings
 
 
 def write_od_to_plate(data, well_name, array_type):
@@ -43,6 +44,7 @@ def write_antigen_report(writer, array_type):
     :return:
     """
     #todo: loops over all antigens for every well.  So if 6x6 arrays of antigens, 6x6x96 calls
+    # is there a more efficent way to do this?
     well_to_image = {v: k for k, v in constants.IMAGE_TO_WELL.items()}
     for antigen_position, antigen in np.ndenumerate(constants.ANTIGEN_ARRAY):
         if antigen == '' or antigen is None:
@@ -65,12 +67,13 @@ def write_antigen_report(writer, array_type):
         # (this function is called once for each OD, INT, BG)
         od_sheet_df = pd.DataFrame(sheet).T
 
+        sheet_name = f'{array_type}_{antigen_position[0]}_{antigen_position[1]}_{antigen}'
+        if len(sheet_name) >= 31:
+            warnings.warn("antigen sheet name is too long, truncating")
+            sheet_name = sheet_name[:31]
+
         od_sheet_df.to_excel(writer,
-                             sheet_name=f''
-                             f'{array_type}_'
-                             f'{antigen_position[0]}_'
-                             f'{antigen_position[1]}_'
-                             f'{antigen}')
+                             sheet_name=sheet_name)
 
 
 def write_to_sheet(sheet_, well_array_, antigen_position_, well_to_image_):

--- a/array_analyzer/load/report.py
+++ b/array_analyzer/load/report.py
@@ -38,6 +38,7 @@ def write_antigen_report(writer, array_type):
     :param array_type: str one of 'od', 'int', 'bg'
     :return:
     """
+    #todo: loops over all antigens for every well.  So if 6x6 arrays of antigens, 6x6x96 calls
     well_to_image = {v: k for k, v in constants.IMAGE_TO_WELL.items()}
     for antigen_position, antigen in np.ndenumerate(constants.ANTIGEN_ARRAY):
         if antigen == '' or antigen is None:
@@ -81,7 +82,6 @@ def write_to_sheet(sheet_, well_array_, antigen_position_, well_to_image_):
     for position, well in np.ndenumerate(well_array_):
         # extract intensity at antigen_position within this well
         if well is None:
-            print(f"WELL IS NONE, position = {position}")
             val = -999
         else:
             val = well[antigen_position_[0], antigen_position_[1]]

--- a/array_analyzer/load/report.py
+++ b/array_analyzer/load/report.py
@@ -5,46 +5,35 @@ import pandas as pd
 import warnings
 
 
-def write_od_to_plate(data, well_name, array_type):
+def write_od_to_plate(data, well_name, well_array):
     """
     Given data from image_parser.compute_od, write the output to an array
         representing its WELL position
     :param data: np.ndarray output from image_parser.compute_od
     :param well_name: str well name
-    :param array_type: str data type
+    :param well_array: np.ndarray of 8x12 format (96 well plate)
     :return:
     """
-    if array_type not in ['od', 'int', 'bg']:
-        raise AttributeError(f"array type {array_type} not implemented!")
-
     if well_name in constants.IMAGE_TO_WELL:
         (row, col) = constants.IMAGE_TO_WELL[well_name]
     else:
         raise AttributeError(f"well name {well_name} is not recognized")
 
-    if data is None:
-        print("\tDATA IS NONE FOR THIS WELL")
-        data = np.ones(shape=(constants.params['rows'], constants.params['columns']))
-
-    if array_type == 'od':
-        constants.WELL_OD_ARRAY[row-1, col-1] = data
-    if array_type == 'int':
-        constants.WELL_INT_ARRAY[row-1, col-1] = data
-    if array_type == 'bg':
-        constants.WELL_BG_ARRAY[row-1, col-1] = data
+    well_array[row-1, col-1] = data
 
 
-def write_antigen_report(writer, array_type):
+def write_antigen_report(writer, well_array, array_type):
     """
     Creates and writes a single Excel worksheet containing:
         - one of OD, INT, or BG values for a SINGLE antigen, in row-col format
         - row-col format is based on 96-well plate: c.WELL_OUTPUT_TEMPLATE
     :param writer: pd.ExcelWriter object
-    :param array_type: str one of 'od', 'int', 'bg'
+    :param well_array: np.ndarray of 8x12 format (96 well plate), Specific to OD, INT, or BG
+    :param array_type: str one of 'od', 'int', 'bg' based on well_array
     :return:
     """
-    #todo: loops over all antigens for every well.  So if 6x6 arrays of antigens, 6x6x96 calls
-    # is there a more efficent way to do this?
+    # todo: loops over all antigens for every well.  So if 6x6 arrays of antigens, 6x6x96 calls
+    #  is there a more efficent way to do this?
     well_to_image = {v: k for k, v in constants.IMAGE_TO_WELL.items()}
     for antigen_position, antigen in np.ndenumerate(constants.ANTIGEN_ARRAY):
         if antigen == '' or antigen is None:
@@ -53,50 +42,29 @@ def write_antigen_report(writer, array_type):
             print(f"writing antigen {antigen} to excel sheets")
 
         sheet = deepcopy(constants.WELL_OUTPUT_TEMPLATE)
-        # loop all wells and write OD, INT, BG of this antigen
-        if array_type == 'od':
-            sheet = write_to_sheet(sheet, constants.WELL_OD_ARRAY, antigen_position, well_to_image)
-        elif array_type == 'int':
-            sheet = write_to_sheet(sheet, constants.WELL_INT_ARRAY, antigen_position, well_to_image)
-        elif array_type == 'bg':
-            sheet = write_to_sheet(sheet, constants.WELL_BG_ARRAY, antigen_position, well_to_image)
-        else:
-            raise AttributeError(f"report array type {array_type} not supported")
 
-        # write the outputs from ONE of the above three to a worksheet
-        # (this function is called once for each OD, INT, BG)
-        od_sheet_df = pd.DataFrame(sheet).T
+        # loop all wells and write OD, INT or BG of this antigen
+        for position, well in np.ndenumerate(well_array):
+            # extract intensity at antigen_position within this well
+            if well is None:
+                val = None
+            else:
+                val = well[antigen_position[0], antigen_position[1]]
+
+            # get the well name describing this position in form "A#"
+            well_name = well_to_image[(position[0] + 1, position[1] + 1)]
+
+            # write a new sheet named "A#"
+            sheet[well_name[0]][int(well_name[1:])] = val
+
+        # write the outputs to a worksheet
+        sheet_df = pd.DataFrame(sheet).T
 
         sheet_name = f'{array_type}_{antigen_position[0]}_{antigen_position[1]}_{antigen}'
         if len(sheet_name) >= 31:
             warnings.warn("antigen sheet name is too long, truncating")
             sheet_name = sheet_name[:31]
 
-        od_sheet_df.to_excel(writer,
-                             sheet_name=sheet_name)
+        sheet_df.to_excel(writer,
+                          sheet_name=sheet_name)
 
-
-def write_to_sheet(sheet_, well_array_, antigen_position_, well_to_image_):
-    """
-
-    :param sheet_:
-    :param well_array_:
-    :param antigen_position_:
-    :param well_to_image_:
-    :return:
-    """
-    # iterate over all 96 well positions
-    for position, well in np.ndenumerate(well_array_):
-        # extract intensity at antigen_position within this well
-        if well is None:
-            val = -999
-        else:
-            val = well[antigen_position_[0], antigen_position_[1]]
-
-        # get the well name describing this position in form "A#"
-        well_name = well_to_image_[(position[0] + 1, position[1] + 1)]
-
-        # write a new sheet named "A#"
-        sheet_[well_name[0]][int(well_name[1:])] = val
-
-    return sheet_

--- a/array_analyzer/load/report.py
+++ b/array_analyzer/load/report.py
@@ -21,6 +21,10 @@ def write_od_to_plate(data, well_name, array_type):
     else:
         raise AttributeError(f"well name {well_name} is not recognized")
 
+    if data is None:
+        print("\tDATA IS NONE FOR THIS WELL")
+        data = np.ones(shape=(constants.params['rows'], constants.params['columns']))
+
     if array_type == 'od':
         constants.WELL_OD_ARRAY[row-1, col-1] = data
     if array_type == 'int':

--- a/array_analyzer/load/report.py
+++ b/array_analyzer/load/report.py
@@ -48,24 +48,16 @@ def write_antigen_report(writer, array_type):
         sheet = deepcopy(constants.WELL_OUTPUT_TEMPLATE)
         # loop all wells and write OD, INT, BG of this antigen
         if array_type == 'od':
-            for od_position, od_well in np.ndenumerate(constants.WELL_OD_ARRAY):
-                od_val = od_well[antigen_position[0], antigen_position[1]]
-                well_name = well_to_image[(od_position[0] + 1, od_position[1] + 1)]
-                sheet[well_name[0]][int(well_name[1:])] = od_val
+            sheet = write_to_sheet(sheet, constants.WELL_OD_ARRAY, antigen_position, well_to_image)
         elif array_type == 'int':
-            for int_position, int_well in np.ndenumerate(constants.WELL_INT_ARRAY):
-                int_val = int_well[antigen_position[0], antigen_position[1]]
-                well_name = well_to_image[(int_position[0] + 1, int_position[1] + 1)]
-                sheet[well_name[0]][int(well_name[1:])] = int_val
+            sheet = write_to_sheet(sheet, constants.WELL_INT_ARRAY, antigen_position, well_to_image)
         elif array_type == 'bg':
-            for bg_position, bg_well in np.ndenumerate(constants.WELL_BG_ARRAY):
-                bg_val = bg_well[antigen_position[0], antigen_position[1]]
-                well_name = well_to_image[(bg_position[0] + 1, bg_position[1] + 1)]
-                sheet[well_name[0]][int(well_name[1:])] = bg_val
+            sheet = write_to_sheet(sheet, constants.WELL_BG_ARRAY, antigen_position, well_to_image)
         else:
             raise AttributeError(f"report array type {array_type} not supported")
 
-        # write the outputs from the above three to a worksheet
+        # write the outputs from ONE of the above three to a worksheet
+        # (this function is called once for each OD, INT, BG)
         od_sheet_df = pd.DataFrame(sheet).T
 
         od_sheet_df.to_excel(writer,
@@ -74,3 +66,30 @@ def write_antigen_report(writer, array_type):
                              f'{antigen_position[0]}_'
                              f'{antigen_position[1]}_'
                              f'{antigen}')
+
+
+def write_to_sheet(sheet_, well_array_, antigen_position_, well_to_image_):
+    """
+
+    :param sheet_:
+    :param well_array_:
+    :param antigen_position_:
+    :param well_to_image_:
+    :return:
+    """
+    # iterate over all 96 well positions
+    for position, well in np.ndenumerate(well_array_):
+        # extract intensity at antigen_position within this well
+        if well is None:
+            print(f"WELL IS NONE, position = {position}")
+            val = -999
+        else:
+            val = well[antigen_position_[0], antigen_position_[1]]
+
+        # get the well name describing this position in form "A#"
+        well_name = well_to_image_[(position[0] + 1, position[1] + 1)]
+
+        # write a new sheet named "A#"
+        sheet_[well_name[0]][int(well_name[1:])] = val
+
+    return sheet_

--- a/array_analyzer/transform/point_registration.py
+++ b/array_analyzer/transform/point_registration.py
@@ -10,20 +10,28 @@ def create_reference_grid(center_point,
     Generate initial spot grid based on image scale, center point, spot distance
     and spot layout (nbr rows and cols).
 
-    :param tuple center_point: (x,y) coordinates of center of grid
+    :param tuple center_point: (row, col) coordinates of center of grid
     :param int nbr_grid_rows: Number of spot rows
     :param int nbr_grid_cols: Number of spot columns
     :param int spot_dist: Distance between spots
-    :return np.array grid_coords: (x, y) coordinates for reference spots (nbr x 2)
+    :return np.array grid_coords: (row, col) coordinates for reference spots (nbr x 2)
     """
-    start_x = center_point[0] - spot_dist * (nbr_grid_cols - 1) / 2
-    start_y = center_point[1] - spot_dist * (nbr_grid_rows - 1) / 2
-    x_vals = np.linspace(start_x, start_x + (nbr_grid_cols - 1) * spot_dist, nbr_grid_cols)
-    y_vals = np.linspace(start_y, start_y + (nbr_grid_rows - 1) * spot_dist, nbr_grid_rows)
-    grid_x, grid_y = np.meshgrid(x_vals, y_vals)
-    grid_x = grid_x.flatten()
-    grid_y = grid_y.flatten()
-    grid_coords = np.vstack([grid_x.T, grid_y.T]).T
+    start_row = center_point[0] - spot_dist * (nbr_grid_rows - 1) / 2
+    start_col = center_point[1] - spot_dist * (nbr_grid_cols - 1) / 2
+    row_vals = np.linspace(
+        start_row,
+        start_row + (nbr_grid_rows - 1) * spot_dist,
+        nbr_grid_rows,
+    )
+    col_vals = np.linspace(
+        start_col,
+        start_col + (nbr_grid_cols - 1) * spot_dist,
+        nbr_grid_cols,
+    )
+    grid_cols, grid_rows = np.meshgrid(col_vals, row_vals)
+    grid_cols = grid_cols.flatten()
+    grid_rows = grid_rows.flatten()
+    grid_coords = np.vstack([grid_rows.T, grid_cols.T]).T
 
     return grid_coords
 

--- a/array_analyzer/utils/mock_regionprop.py
+++ b/array_analyzer/utils/mock_regionprop.py
@@ -1,23 +1,49 @@
 from skimage.morphology import disk
 import numpy as np
+import warnings
+
+
 class MockRegionprop:
 
     def __init__(self,
                  intensity_image,
                  centroid,
                  image=None,
-                 mean_intensity=None,
                  label=None,
                  bbox=None,
                  ):
         self.centroid = centroid
-        self.mean_intensity = mean_intensity
         self.label = label
         self.intensity_image = intensity_image
-        if image is None:
-            image = disk(int(intensity_image.shape[0] / 2), dtype=np.bool_)
-        self.image = image
-        self.mean_intensity = np.mean(intensity_image[image])
-        self.median_intensity = np.median(intensity_image[image])
-        self.intensity_image = intensity_image * image
         self.bbox = bbox
+        if image is None:
+            self.image = disk(int(intensity_image.shape[0] / 2), dtype=np.bool_)
+        else:
+            self.image = image
+
+        if not self._check_image_shape():
+            self.median_intensity = -1
+        else:
+            self._set_median_intensity()
+            self._set_mean_intensity()
+            self._set_intensity_image()
+
+    def _set_mean_intensity(self):
+        self.mean_intensity = np.mean(self.intensity_image[self.image])
+
+    def _set_median_intensity(self):
+        self.median_intensity = np.median(self.intensity_image[self.image])
+
+    def _set_intensity_image(self):
+        self.intensity_image = self.intensity_image * self.image
+
+    def _check_image_shape(self):
+        if self.intensity_image == [] or self.intensity_image is None:
+            warnings.warn("MockRegionProp received an empty intensity image")
+            return False
+        if self.image == [] or self.image is None:
+            warnings.warn("MockRegionProp received an empty boolean mask")
+            return False
+        if self.intensity_image.shape != self.image.shape:
+            warnings.warn("MockRegionProp received shape-mismatched mask and image")
+            return False

--- a/array_analyzer/workflows/interpolation_wf.py
+++ b/array_analyzer/workflows/interpolation_wf.py
@@ -92,9 +92,9 @@ def interp(input_dir, output_dir):
         pd_OD.to_excel(xlwriter_od_well, sheet_name=well_name)
 
         # populate 96-well plate constants with OD, INT, BG arrays
-        report.write_od_to_plate(od_well, well_name, 'od')
-        report.write_od_to_plate(int_well, well_name, 'int')
-        report.write_od_to_plate(bg_well, well_name, 'bg')
+        report.write_od_to_plate(od_well, well_name, constants.WELL_OD_ARRAY)
+        report.write_od_to_plate(int_well, well_name, constants.WELL_INT_ARRAY)
+        report.write_od_to_plate(bg_well, well_name, constants.WELL_BG_ARRAY)
 
         stop = time.time()
         print(f"\ttime to process={stop-start}")
@@ -142,13 +142,19 @@ def interp(input_dir, output_dir):
     xlwriter_od_well.close()
 
     # create excel writers to write reports
-    xlwriter_od = pd.ExcelWriter(os.path.join(constants.RUN_PATH, 'python_median_ODs.xlsx'))
-    xlwriter_int = pd.ExcelWriter(os.path.join(constants.RUN_PATH, 'python_median_intensities.xlsx'))
-    xlwriter_bg = pd.ExcelWriter(os.path.join(constants.RUN_PATH, 'python_median_backgrounds.xlsx'))
+    xlwriter_od = pd.ExcelWriter(
+        os.path.join(constants.RUN_PATH, 'python_median_ODs.xlsx')
+    )
+    xlwriter_int = pd.ExcelWriter(
+        os.path.join(constants.RUN_PATH, 'python_median_intensities.xlsx')
+    )
+    xlwriter_bg = pd.ExcelWriter(
+        os.path.join(constants.RUN_PATH, 'python_median_backgrounds.xlsx')
+    )
 
-    report.write_antigen_report(xlwriter_od, 'od')
-    report.write_antigen_report(xlwriter_int, 'int')
-    report.write_antigen_report(xlwriter_bg, 'bg')
+    report.write_antigen_report(xlwriter_od, constants.WELL_OD_ARRAY, 'od')
+    report.write_antigen_report(xlwriter_int, constants.WELL_INT_ARRAY, 'int')
+    report.write_antigen_report(xlwriter_bg, constants.WELL_BG_ARRAY, 'bg')
 
     xlwriter_od.close()
     xlwriter_int.close()

--- a/array_analyzer/workflows/registration_workflow.py
+++ b/array_analyzer/workflows/registration_workflow.py
@@ -175,9 +175,9 @@ def point_registration(input_dir, output_dir):
         )
 
         # populate 96-well plate constants with OD, INT, BG arrays
-        report.write_od_to_plate(od_well, well_name, 'od')
-        report.write_od_to_plate(int_well, well_name, 'int')
-        report.write_od_to_plate(bg_well, well_name, 'bg')
+        report.write_od_to_plate(od_well, well_name, constants.WELL_OD_ARRAY)
+        report.write_od_to_plate(int_well, well_name, constants.WELL_INT_ARRAY)
+        report.write_od_to_plate(bg_well, well_name, constants.WELL_BG_ARRAY)
 
         # Write ODs per well
         pd_od = pd.DataFrame(od_well)
@@ -234,9 +234,9 @@ def point_registration(input_dir, output_dir):
         os.path.join(constants.RUN_PATH, 'median_backgrounds.xlsx'),
     )
 
-    report.write_antigen_report(xlwriter_od, 'od')
-    report.write_antigen_report(xlwriter_int, 'int')
-    report.write_antigen_report(xlwriter_bg, 'bg')
+    report.write_antigen_report(xlwriter_od, constants.WELL_OD_ARRAY, 'od')
+    report.write_antigen_report(xlwriter_int, constants.WELL_INT_ARRAY, 'int')
+    report.write_antigen_report(xlwriter_bg, constants.WELL_BG_ARRAY, 'bg')
 
     xlwriter_od.close()
     xlwriter_int.close()

--- a/tests/test_debug_plots.py
+++ b/tests/test_debug_plots.py
@@ -1,0 +1,9 @@
+import pytest
+
+import array_analyzer.load as load
+import os
+
+
+def test_nonetype_integration():
+    pass
+

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -60,3 +60,11 @@ def test_xlsx(create_good_xlsx):
     output_dir = create_good_xlsx
     MetaData(output_dir, output_dir)
 
+
+def test_nonetype_well_array(create_good_xlsx):
+    constants.METADATA_EXTENSION = 'xlsx'
+    output_dir = create_good_xlsx
+    MetaData(output_dir, output_dir)
+    assert constants.WELL_BG_ARRAY[0][0] is None
+    assert constants.WELL_INT_ARRAY[0][0] is None
+    assert constants.WELL_OD_ARRAY[0][0] is None


### PR DESCRIPTION
***BUG FIX***
1) This PR fixes issue #63, which describes a complaint that the `od_well` object is not subscriptable. This occurs when there is a well registration failure, causing the `od_well` to not be written.  Later, when all the `od_wells` are pulled for report generation, the error is thrown.

2) This PR also fixes another bug regarding MockRegionprop -- if the shape of the supplied image is different from the shape of the "disk" mask, it will throw an error.  This occurred in rare cases where the spot centroid is near an image edge, and sometimes other cases.

3) A secondary problem occurred when trying to fix this:
- the written excel spreadsheets would open with a warning from Excel about corrupted data.  It would attempt to fix, but not obviously do anything.
- the cause of this warning is that an antigen worksheet is written with too many characters (>31).

***Solution***
1) The Nonetype problem is solved by including a check at the time of report generation.  Now, when None is found for the well, it will return -999 (rather than attempt to subscript).
2) This PR modifies the way MockRegionprop automatically calculates median intensity.  It now includes a shape check before attempting to slice into the supplied image data.
3) This PR also contains a check on that length and will auto-truncate if necessary.