### PR TITLE
Increase number of outliers allowed in grid registration 

### DIFF
--- a/array_analyzer/transform/point_registration.py
+++ b/array_analyzer/transform/point_registration.py
@@ -196,7 +196,7 @@ class ParticleFilter:
         knn.train(dst, cv.ml.ROW_SAMPLE, labels)
         # Make sure we don't have too many outliers
         if nbr_outliers > 0:
-            if len(labels) < nbr_outliers + 5 or self.fiducial_coords.shape[0] < nbr_outliers + 5:
+            if len(labels) < nbr_outliers + 5 or self.fiducial_coords.shape[0] - nbr_outliers < 2:
                 nbr_outliers = 1
         self.logger.debug(
             "Particle filter, number of outliers: {}".format(nbr_outliers),

--- a/array_analyzer/transform/point_registration.py
+++ b/array_analyzer/transform/point_registration.py
@@ -187,7 +187,8 @@ class ParticleFilter:
         :param float iter_decrease: Reduce standard deviations each iterations to slow
             down permutations
         :param int nbr_outliers: If registration hasn't converged, remove worst fitted
-            spots when running particle filter
+            spots when running particle filter. Maximum nbr_outliers allowed is
+            min(n(fiducial) - 2, n(spots) -2)
         """
         # Use kNN module to petrain spot coords
         dst = self.spot_coords.copy().astype(np.float32)
@@ -196,8 +197,8 @@ class ParticleFilter:
         knn.train(dst, cv.ml.ROW_SAMPLE, labels)
         # Make sure we don't have too many outliers
         if nbr_outliers > 0:
-            if len(labels) < nbr_outliers + 5 or self.fiducial_coords.shape[0] - nbr_outliers < 2:
-                nbr_outliers = 1
+            if min(len(labels) - nbr_outliers, self.fiducial_coords.shape[0] - nbr_outliers) < 2:
+                nbr_outliers = min(len(labels) - 2, self.fiducial_coords.shape[0] - 2)
         self.logger.debug(
             "Particle filter, number of outliers: {}".format(nbr_outliers),
         )


### PR DESCRIPTION
This PR increases the number of outlier fiducial spots allowed in grid registration up to 3 when n(fiducial)=5, which was constrained to be 1. This is necessary to get the OD from images where some fiducials are not detected in @lenafb 's recent data.   

@jennyfolkesson I submitted an IT request to add you to Biohub Github so I can add you as a reviewer too.